### PR TITLE
Add Laravel 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php" : ">=5.5.0",
-        "illuminate/support": "^5.1"
+        "illuminate/support": "^5.1|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.4",


### PR DESCRIPTION
Just a quick update to `composer.json` so it can be used with Laravel 6. I've tested installing this by pointing to the fork and it seems to work without issues.